### PR TITLE
PDEV-826: Fails early if a CloudFormation export value is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
 
 ### Fixed
 
-- Fails early if a CloudFormation export value is empty, which can happen if the export value is not found or if the export value is empty.
-- Drop support for the obsolete `*|::|` in cloud formation exported value.
+- Fail early if a CloudFormation export value is missing or empty.
+- Drop support for the obsolete `*|::|` delimiter in CloudFormation export values.
 
 ## [4.0.1] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.0.2] - 2026-06-18
+
+### Fixed
+
+- Fails early if a CloudFormation export value is empty, which can happen if the export value is not found or if the export value is empty.
+- Drop support for the obsolete `*|::|` in cloud formation exported value.
+
 ## [4.0.1] - 2026-05-11
 
 ### Fixed

--- a/action.yaml
+++ b/action.yaml
@@ -153,14 +153,21 @@ runs:
 
         function readExport {
           local value="$(aws cloudformation list-exports --query "Exports[?Name=='${{ steps.account_information.outputs.name }}-${2}'].Value" --output text)"
-          yq -i "${1} = \"${value#*|::|}\"" "${3}"
+          if [ -z "${value}" ]; then
+            echo "::error::CloudFormation export ${{ steps.account_information.outputs.name }}-${2} not found"
+            exit 1
+          fi
+          yq -i "${1} = \"${value}\"" "${3}"
         }
 
         # ARN for secret name:
         # arn:aws:secretsmanager:${region}:${account}:secret:${secret_name}-${version}
         function readSecretName {
-          local value="$(aws cloudformation list-exports --query "Exports[?Name=='${{ steps.account_information.outputs.name }}-${2}'].Value" --output text)"
-          local secret_arn="${value#*|::|}"
+          local secret_arn="$(aws cloudformation list-exports --query "Exports[?Name=='${{ steps.account_information.outputs.name }}-${2}'].Value" --output text)"
+          if [ -z "${value}" ]; then
+            echo "::error::CloudFormation export ${{ steps.account_information.outputs.name }}-${2} not found"
+            exit 1
+          fi
           local secret_long_name=${secret_arn##*:secret:}
           yq -i "${1} =\"${secret_long_name%-*}\"" "${3}"
         }

--- a/action.yaml
+++ b/action.yaml
@@ -154,7 +154,7 @@ runs:
         function readExport {
           local value="$(aws cloudformation list-exports --query "Exports[?Name=='${{ steps.account_information.outputs.name }}-${2}'].Value" --output text)"
           if [ -z "${value}" ]; then
-            echo "::error::CloudFormation export ${{ steps.account_information.outputs.name }}-${2} not found"
+            echo "::error::CloudFormation export ${{ steps.account_information.outputs.name }}-${2} not found or empty"
             exit 1
           fi
           yq -i "${1} = \"${value}\"" "${3}"
@@ -163,12 +163,12 @@ runs:
         # ARN for secret name:
         # arn:aws:secretsmanager:${region}:${account}:secret:${secret_name}-${version}
         function readSecretName {
-          local secret_arn="$(aws cloudformation list-exports --query "Exports[?Name=='${{ steps.account_information.outputs.name }}-${2}'].Value" --output text)"
+          local value="$(aws cloudformation list-exports --query "Exports[?Name=='${{ steps.account_information.outputs.name }}-${2}'].Value" --output text)"
           if [ -z "${value}" ]; then
-            echo "::error::CloudFormation export ${{ steps.account_information.outputs.name }}-${2} not found"
+            echo "::error::CloudFormation export ${{ steps.account_information.outputs.name }}-${2} not found or empty"
             exit 1
           fi
-          local secret_long_name=${secret_arn##*:secret:}
+          local secret_long_name=${value##*:secret:}
           yq -i "${1} =\"${secret_long_name%-*}\"" "${3}"
         }
 


### PR DESCRIPTION
A missing (or empty) CloudFormation export now triggers an early failure:

<img width="1405" height="348" alt="Screenshot 2026-06-18 at 18 06 25" src="https://github.com/user-attachments/assets/d4405a00-2d92-4f48-8acd-974c0557cd1c" />
