### PR TITLE
PDEV-826: Fails early if a CloudFormation export value is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.0.2] - 2026-06-18
+
+### Fixed
+
+- Fail early if a CloudFormation export value is missing or empty.
+- Drop support for the obsolete `*|::|` delimiter in CloudFormation export values.
+
 ## [4.0.1] - 2026-05-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -124,8 +124,6 @@ purpose-specific `value.yaml` from the project. The `helm_value_command` file is
 | readExport     | sets the *key* to the CloudFormation export named *value*                                   |
 | readSecretName | sets the *key* to the name of the secret defined by the CloudFormation export named *value* |
 
-The action strips any prefix that matches `.*|::|` from the value read from CloudFormation.
-
 As it reads the command line-by-line, it substitutes these variables
 
 | name           | description                          |

--- a/action.yaml
+++ b/action.yaml
@@ -153,15 +153,22 @@ runs:
 
         function readExport {
           local value="$(aws cloudformation list-exports --query "Exports[?Name=='${{ steps.account_information.outputs.name }}-${2}'].Value" --output text)"
-          yq -i "${1} = \"${value#*|::|}\"" "${3}"
+          if [ -z "${value}" ]; then
+            echo "::error::CloudFormation export ${{ steps.account_information.outputs.name }}-${2} not found or empty"
+            exit 1
+          fi
+          yq -i "${1} = \"${value}\"" "${3}"
         }
 
         # ARN for secret name:
         # arn:aws:secretsmanager:${region}:${account}:secret:${secret_name}-${version}
         function readSecretName {
           local value="$(aws cloudformation list-exports --query "Exports[?Name=='${{ steps.account_information.outputs.name }}-${2}'].Value" --output text)"
-          local secret_arn="${value#*|::|}"
-          local secret_long_name=${secret_arn##*:secret:}
+          if [ -z "${value}" ]; then
+            echo "::error::CloudFormation export ${{ steps.account_information.outputs.name }}-${2} not found or empty"
+            exit 1
+          fi
+          local secret_long_name=${value##*:secret:}
           yq -i "${1} =\"${secret_long_name%-*}\"" "${3}"
         }
 


### PR DESCRIPTION
A failed deployment:
<img width="1405" height="348" alt="Screenshot 2026-06-18 at 18 06 25" src="https://github.com/user-attachments/assets/9a54df57-7e83-4860-9ee2-20848daa7c72" />
