### PR TITLE
Refuse a deploy that would downgrade the environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [4.2.0] - 2026-08-07
+
+### Added
+
+- A deploy is refused when the incoming chart version is older than the one already released in the
+  namespace, unless the new `allow_downgrade` input says otherwise. Two deploys that never overlap are
+  ordered by nothing: build duration varies by a factor of five on some repositories, so a small change
+  merged second can overtake a large one merged first and land the older version last — both runs green,
+  nothing reporting it. Serialising concurrent deploys does not help, because these never contend.
+  `allow_downgrade` exists because a rollback is a legitimate, deliberate act; the callers that perform
+  one set it, and the automated release chain never does.
+
 ## [4.1.1] - 2026-07-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,11 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   merged second can overtake a large one merged first and land the older version last — both runs green,
   nothing reporting it. Serialising concurrent deploys does not help, because these never contend.
   `allow_downgrade` exists because a rollback is a legitimate, deliberate act; the callers that perform
-  one set it, and the automated release chain never does.
+  one set it, and the automated release chain never does. A failure to list releases is reported rather
+  than read as "nothing deployed yet", which would wave the check through exactly when the environment
+  is least understood, and build metadata is stripped before comparing since SemVer gives it no
+  precedence. Prerelease ordering is left to `sort -V`, which is not strict SemVer about it — callers
+  deploying prereleases, such as feature builds, set `allow_downgrade` for that reason.
 
 ## [4.1.1] - 2026-07-14
 

--- a/action.yaml
+++ b/action.yaml
@@ -253,14 +253,29 @@ runs:
         # merged first and land an older version last — with both runs green and
         # nothing reporting it. Serialising concurrent deploys does not help,
         # because these never contend.
-        deployed="$(helm list --namespace "${{ inputs.namespace }}" --filter "^${{ inputs.component_name }}$" \
-          --output json 2>/dev/null | jq -r '.[0].chart // ""' | sed -E 's|^.*-([0-9]+\.[0-9]+\.[0-9]+.*)$|\1|')"
+        # helm list failing is a real condition — no cluster, no credentials — and
+        # must not be mistaken for "nothing is deployed yet", which would wave
+        # this check through exactly when the environment is least understood.
+        if ! releases="$(helm list --namespace "${{ inputs.namespace }}" \
+            --filter "^${{ inputs.component_name }}$" --output json)"; then
+          echo "::error::could not list releases in ${{ inputs.namespace }}"
+          exit 1
+        fi
+        deployed="$(jq -r '.[0].chart // ""' <<<"${releases}" |
+          sed -E 's|^.*-([0-9]+\.[0-9]+\.[0-9]+.*)$|\1|')"
 
-        if [ -n "${deployed}" ] && [ "${deployed}" != "${{ inputs.chart_version }}" ]; then
+        # SemVer says build metadata carries no precedence, but sort -V orders on
+        # it, so 1.2.3+1 against 1.2.3+2 would read as a downgrade. Compare
+        # without it.
+        readonly incoming="${{ inputs.chart_version }}"
+        deployed_core="${deployed%%+*}"
+        incoming_core="${incoming%%+*}"
+
+        if [ -n "${deployed}" ] && [ "${deployed_core}" != "${incoming_core}" ]; then
           # sort -V puts the older version first; if that is the incoming one,
           # this deploy would move the environment backwards.
-          older="$(printf '%s\n%s\n' "${deployed}" "${{ inputs.chart_version }}" | sort -V | head -n1)"
-          if [ "${older}" == "${{ inputs.chart_version }}" ]; then
+          older="$(printf '%s\n%s\n' "${deployed_core}" "${incoming_core}" | sort -V | head -n1)"
+          if [ "${older}" == "${incoming_core}" ]; then
             if [ "${{ inputs.allow_downgrade }}" = "true" ]; then
               echo "::warning::deploying ${{ inputs.chart_version }} over ${deployed} — downgrade allowed explicitly"
             else

--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,12 @@ inputs:
     description: "The name of the component being deployed, it is the helm release name;
                   it also serves as the default base name for the kubernetes namespace."
     required: true
+  allow_downgrade:
+    description: >-
+      Set true to deploy a chart version older than the one already released in the namespace.
+      A rollback is a deliberate act; an overtaking build is not.
+    required: false
+    default: "false"
   dry_run:
     description: "Set to true to perform a helm dry-run deployment"
     required: false
@@ -241,6 +247,38 @@ runs:
         
         echo "${{ inputs.github_token }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
         
+        # Refuse to go backwards. Two deploys that never overlap are not ordered
+        # by anything: build duration varies by a factor of five on some
+        # repositories, so a small change merged second can overtake a large one
+        # merged first and land an older version last — with both runs green and
+        # nothing reporting it. Serialising concurrent deploys does not help,
+        # because these never contend.
+        deployed="$(helm list --namespace "${{ inputs.namespace }}" --filter "^${{ inputs.component_name }}$" \
+          --output json 2>/dev/null | jq -r '.[0].chart // ""' | sed -E 's|^.*-([0-9]+\.[0-9]+\.[0-9]+.*)$|\1|')"
+
+        if [ -n "${deployed}" ] && [ "${deployed}" != "${{ inputs.chart_version }}" ]; then
+          # sort -V puts the older version first; if that is the incoming one,
+          # this deploy would move the environment backwards.
+          older="$(printf '%s\n%s\n' "${deployed}" "${{ inputs.chart_version }}" | sort -V | head -n1)"
+          if [ "${older}" == "${{ inputs.chart_version }}" ]; then
+            if [ "${{ inputs.allow_downgrade }}" = "true" ]; then
+              echo "::warning::deploying ${{ inputs.chart_version }} over ${deployed} — downgrade allowed explicitly"
+            else
+              echo "::error::${{ inputs.purpose }} runs ${deployed}; refusing to deploy the older ${{ inputs.chart_version }}"
+              {
+                echo "# Refused: this would downgrade ${{ inputs.purpose }}"
+                echo "| | version |"
+                echo "|---|---|"
+                echo "| deployed | \`${deployed}\` |"
+                echo "| incoming | \`${{ inputs.chart_version }}\` |"
+                echo
+                echo "If the older version is genuinely wanted — a rollback — set \`allow_downgrade: true\`."
+              } >>"${GITHUB_STEP_SUMMARY}"
+              exit 1
+            fi
+          fi
+        fi
+
         echo "🚀🚀🚀 Upgrading ${{ inputs.purpose }} in ${{ steps.purpose_config.outputs.cluster_name }} 🚀🚀🚀"
         echo "${{ inputs.chart_name }}:${{ inputs.chart_version }}"
         echo "🚀🚀🚀 ==================== 🚀🚀🚀"


### PR DESCRIPTION
## The failure this closes

Version N and N+1 both build. N+1's build is faster, so it deploys first. N deploys afterwards and the environment ends up on the **older** version — both runs green, nothing reporting it.

That is not contrived. `operations` builds were measured between 4.0 and 22 minutes on the same day, and the spread tracks how much of the tree changed. A one-line change genuinely does overtake a large one.

Serialising concurrent deploys — which `operations` now does — cannot help here, because these two never contend.

## What it does

Before `helm upgrade`, compares the chart version already released in the namespace against the incoming one and fails if the incoming is older. `allow_downgrade: true` permits it, because a rollback is a legitimate deliberate act; the automated release chain never sets it, and the one-off dispatch path does when a human asks for an earlier version.

This has to live here rather than in the calling repository: the comparison needs cluster access, and credentials are configured inside this action.

## Note for callers doing feature builds

A feature build carries a prerelease version, which sorts *below* the release it is derived from — so a feature deploy onto an environment already running that release reads as a downgrade. Callers that deploy feature builds should set `allow_downgrade` from the same condition they already use for `clean_up`.

Found while adopting queued CI/CD ([PDEV-1408](https://linear.app/ardacards/issue/PDEV-1408)) — after a real collision left `operations` 7.0.1 published but deployed nowhere.

> [!note]
> Authored by Claude Opus 5 for jmpicnic